### PR TITLE
increase network connection limits

### DIFF
--- a/cloud-compose/templates/cluster.sh
+++ b/cloud-compose/templates/cluster.sh
@@ -3,3 +3,4 @@
 {% include "system.mounts.sh" %}
 {% include "docker.config.sh" %}
 {% include "docker_compose.run.sh" %}
+{% include "system.network_conf.sh" %}

--- a/cloud-compose/templates/system.network_conf.sh
+++ b/cloud-compose/templates/system.network_conf.sh
@@ -1,0 +1,12 @@
+# system.network_conf.sh
+cat << EOF > /etc/sysctl.d/network.conf
+net.ipv4.tcp_fin_timeout = 30
+net.ipv4.tcp_tw_reuse = 1
+net.nf_conntrack_max = 512000
+net.ipv4.tcp_keepalive_intvl = 60 
+net.ipv4.tcp_keepalive_probes = 10 
+net.ipv4.tcp_keepalive_time = 600
+net.netfilter.nf_conntrack_tcp_timeout_established = 1800
+EOF
+echo 128000 > /sys/module/nf_conntrack/parameters/hashsize
+sysctl --system


### PR DESCRIPTION
This change increases the network connection limits and is useful on clusters running nginx or apache. This change was tested on docker-mongodb, but I have not created an ECS cluster with this configuration.
