### PR TITLE
Add support for task iam role credential fetch

### DIFF
--- a/cloud-compose/templates/docker-compose.override.yml
+++ b/cloud-compose/templates/docker-compose.override.yml
@@ -1,6 +1,8 @@
 version: '2'
 services:
   ecs:
+    ports:
+      - 51678-51679:51678-51679
     environment:
       INSTANCE_IP: ${INSTANCE_IP}
       ECS_CLUSTER: {{ name }}
@@ -10,6 +12,7 @@ services:
       {%- if ECS_ENGINE_AUTH_DATA is defined %}
       ECS_ENGINE_AUTH_TYPE: {{ ECS_ENGINE_AUTH_TYPE }}
       {%- endif %}
+      ECS_ENABLE_TASK_IAM_ROLE: "true"
     {%- if logging is defined and logging.driver is defined and logging.driver == "awslogs" %}
     logging:
       driver: awslogs

--- a/cloud-compose/templates/docker-compose.override.yml
+++ b/cloud-compose/templates/docker-compose.override.yml
@@ -1,8 +1,6 @@
 version: '2'
 services:
   ecs:
-    ports:
-      - 51678-51679:51678-51679
     environment:
       INSTANCE_IP: ${INSTANCE_IP}
       ECS_CLUSTER: {{ name }}
@@ -12,7 +10,6 @@ services:
       {%- if ECS_ENGINE_AUTH_DATA is defined %}
       ECS_ENGINE_AUTH_TYPE: {{ ECS_ENGINE_AUTH_TYPE }}
       {%- endif %}
-      ECS_ENABLE_TASK_IAM_ROLE: "true"
     {%- if logging is defined and logging.driver is defined and logging.driver == "awslogs" %}
     logging:
       driver: awslogs

--- a/cloud-compose/templates/system.network_conf.sh
+++ b/cloud-compose/templates/system.network_conf.sh
@@ -7,6 +7,9 @@ net.ipv4.tcp_keepalive_intvl = 60
 net.ipv4.tcp_keepalive_probes = 10 
 net.ipv4.tcp_keepalive_time = 600
 net.netfilter.nf_conntrack_tcp_timeout_established = 1800
+net.ipv4.conf.all.route_localnet = 1
 EOF
 echo 128000 > /sys/module/nf_conntrack/parameters/hashsize
 sysctl --system
+iptables -t nat -A PREROUTING -p tcp -d 169.254.170.2 --dport 80 -j DNAT --to-destination 127.0.0.1:51679
+iptables -t nat -A OUTPUT -d 169.254.170.2 -p tcp -m tcp --dport 80 -j REDIRECT --to-ports 51679

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "/sys/fs/cgroup:/sys/fs/cgroup:ro"
       - "/var/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro"
     ports:
-      - 51678:51678
+      - 51678-51679:51678-51679
     environment:
       INSTANCE_IP: 127.0.0.1
       ECS_LOGFILE: /log/ecs-agent.log
@@ -18,3 +18,4 @@ services:
       ECS_DATADIR: /data
       ECS_CLUSTER: local_test
       ECS_AVAILABLE_LOGGING_DRIVERS: '["json-file","syslog","journald","gelf","fluentd","awslogs"]'
+      ECS_ENABLE_TASK_IAM_ROLE: "true"


### PR DESCRIPTION
This enables IAM roles for ECS Tasks running on a cluster. A task's containers can fetch temporary credentials tied to the prescribed IAM role via the endpoint `169.254.170.2$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI`, where `$AWS_CONTAINER...` is an environment variable set by the ECS agent.

See [Amazon's ECS documentation](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) for more information on Task IAM roles.
