### PR TITLE
Fix datadog configuration options

### DIFF
--- a/cloud-compose/templates/datadog.docker.sh
+++ b/cloud-compose/templates/datadog.docker.sh
@@ -5,6 +5,7 @@ sh -c "sed 's/api_key:.*/api_key: $DATADOG_API_KEY/' /etc/dd-agent/datadog.conf.
 sh -c "sed 's/api_key:.*/api_key: {{DATADOG_API_KEY}}/' /etc/dd-agent/datadog.conf.example > /etc/dd-agent/datadog.conf"
 {%- endif %}
 # Note 'bind_host: 0.0.0.0' will break the built in JMX collector on the host, but it is required for sending metrics directly from Docker containers to the dd-agent
-echo 'bind_host: 0.0.0.0' >> /etc/dd-agent/datadog.conf
-echo 'process_agent_enabled: true' >> /etc/dd-agent/datadog.conf
+sh -c "sed -i 's/# bind_host:.*/bind_host: 0.0.0.0/' /etc/dd-agent/datadog.conf"
+sh -c "sed -i '/\[Main\]/aprocess_agent_enabled: true' /etc/dd-agent/datadog.conf"
+
 service datadog-agent restart


### PR DESCRIPTION
This fixes addition of options in the `datadog.conf` configuration file, which now employs multiple sections by default. 

