### PR TITLE
Update to host mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   ecs:
     container_name: ecs-agent
     image: amazon/amazon-ecs-agent:latest
+    network_mode: "host"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "/var/log/ecs/:/log"


### PR DESCRIPTION
Update ecs agent to host mode as outlined in this issue https://github.com/aws/amazon-ecs-agent/issues/1930

It turns out that running the agent in bridge mode is a security risk